### PR TITLE
Add Ed25519 API key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.0] - 2026-JUN-02
+
+### Added
+
+- Ed25519 API key support. Key type is auto-detected: Ed25519 keys are signed with EdDSA, while ECDSA (P-256) keys continue to sign with ES256 as before. Ed25519 keys are accepted as PKCS8 PEM or 64-byte raw base64.
+
 ## [0.1.0] - 2024-SEP-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase-sample/advanced-trade-sdk-ts",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf dist && tsc",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,8 +15,9 @@
  */
 export const BASE_URL = 'api.coinbase.com';
 export const API_PREFIX = '/api/v3/brokerage/';
-export const ALGORITHM = 'ES256';
-export const VERSION = '0.1.0';
+export const ALGORITHM_ECDSA = 'ES256';
+export const ALGORITHM_ED25519 = 'EdDSA';
+export const VERSION = '0.3.0';
 export const USER_AGENT = `coinbase-advanced-ts/${VERSION}`;
 export const JWT_ISSUER = 'cdp';
 export const API_BASE_PATH = 'https://' + BASE_URL + API_PREFIX;

--- a/src/rest/credentials/index.ts
+++ b/src/rest/credentials/index.ts
@@ -13,9 +13,90 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ALGORITHM, JWT_ISSUER } from '../../constants';
+import { ALGORITHM_ECDSA, ALGORITHM_ED25519, JWT_ISSUER } from '../../constants';
 import * as jwt from 'jsonwebtoken';
 import * as crypto from 'crypto';
+
+interface LoadedKey {
+  key: crypto.KeyObject;
+  algorithm: string;
+}
+
+/**
+ * Supported:
+ *   - ECDSA P-256 PEM (SEC1 or PKCS8)              -> ES256
+ *   - Ed25519 PEM (PKCS8)                          -> EdDSA
+ *   - Ed25519 raw base64, 64 bytes (seed + public) -> EdDSA
+ */
+function loadPrivateKey(secret: string): LoadedKey {
+  if (secret.trimStart().startsWith('-----BEGIN')) {
+    const key = crypto.createPrivateKey(secret);
+    return { key, algorithm: algorithmForKey(key) };
+  }
+
+  const raw = Buffer.from(secret.replace(/\s/g, ''), 'base64');
+  if (raw.length !== 64) {
+    throw new Error(
+      'Private key is neither PEM nor a valid 64-byte base64 Ed25519 key ' +
+        `(got ${raw.length} bytes). `
+      );
+  }
+  const key = crypto.createPrivateKey({
+    format: 'jwk',
+    key: {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      d: raw.subarray(0, 32).toString('base64url'),
+      x: raw.subarray(32).toString('base64url'),
+    },
+  });
+  return { key, algorithm: ALGORITHM_ED25519 };
+}
+
+function algorithmForKey(key: crypto.KeyObject): string {
+  switch (key.asymmetricKeyType) {
+    case 'ed25519':
+      return ALGORITHM_ED25519;
+    case 'ec':
+      return ALGORITHM_ECDSA;
+    default:
+      throw new Error(
+        `Unsupported private key type: ${key.asymmetricKeyType ?? 'unknown'}. ` +
+          'Expected an ECDSA (P-256) or Ed25519 key.'
+      );
+  }
+}
+
+function buildJwt(loaded: LoadedKey, accessKey: string, uri: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: JWT_ISSUER,
+    nbf: now,
+    exp: now + 120,
+    sub: accessKey,
+    uri,
+  };
+
+  const header = {
+    alg: loaded.algorithm,
+    kid: accessKey,
+    nonce: crypto.randomBytes(16).toString('hex'),
+  };
+
+  if (loaded.algorithm === ALGORITHM_ED25519) {
+    const encode = (obj: unknown) =>
+      Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const signingInput = `${encode(header)}.${encode(payload)}`;
+    const data = new Uint8Array(Buffer.from(signingInput));
+    const signature = crypto.sign(null, data, loaded.key);
+    return `${signingInput}.${signature.toString('base64url')}`;
+  }
+
+  return jwt.sign(payload, loaded.key, {
+    algorithm: loaded.algorithm as jwt.Algorithm,
+    header,
+  });
+}
 
 export class CoinbaseAdvTradeCredentials {
   private accessKey: string | undefined;
@@ -37,32 +118,15 @@ export class CoinbaseAdvTradeCredentials {
       return {};
     }
 
+    const loaded = loadPrivateKey(this.secretKey);
+
     // Drop protocol and query parameters
     const jwtUri = `${requestMethod} ${
       uri.replace('https://', '').replace('http://', '').split('?')[0]
     }`;
 
-    const payload = {
-      iss: JWT_ISSUER,
-      nbf: Math.floor(Date.now() / 1000),
-      exp: Math.floor(Date.now() / 1000) + 120,
-      sub: this.accessKey,
-      uri: jwtUri,
-    };
-
-    const header = {
-      alg: ALGORITHM,
-      kid: this.accessKey,
-      nonce: crypto.randomBytes(16).toString('hex'),
-    };
-
-    const signature = jwt.sign(payload, this.secretKey, {
-      algorithm: ALGORITHM,
-      header,
-    });
-
     return {
-      Authorization: `Bearer ${signature}`,
+      Authorization: `Bearer ${buildJwt(loaded, this.accessKey, jwtUri)}`,
     };
   }
 }


### PR DESCRIPTION
## What

Adds Ed25519 API key support to the JWT signing path. The key type is auto-detected from the private key: Ed25519 keys sign with EdDSA, ECDSA (P-256) keys keep signing with ES256 as before. Existing ECDSA keys keep working with no changes.

Ed25519 keys are accepted as PKCS8 PEM or 64-byte raw base64 (the form the CDP portal hands out).

## Why

The SDK was hardcoded to ES256, so CDP Ed25519 keys couldn't authenticate at all. This brings the TS SDK in line with the Python SDK, which already supports both key types.

## Changes

- `src/rest/credentials/index.ts`: detect the key type via `crypto.createPrivateKey().asymmetricKeyType`; sign EdDSA with Node's crypto directly (jsonwebtoken has no EdDSA support), ES256 still goes through jsonwebtoken.
- `src/constants.ts`: split `ALGORITHM` into `ALGORITHM_ECDSA` / `ALGORITHM_ED25519`, and bump `VERSION` to 0.3.0 (it was stale at 0.1.0 and drives the User-Agent).
- Version bump to 0.3.0 and a CHANGELOG entry.

Note: only the 64-byte raw base64 form is accepted (not the 32-byte seed-only form). That keeps the import simple via JWK and matches what the portal issues. Since Ed25519 was never in a released version, this isn't a behavior change for anyone.

## Test plan

Verified locally (tests not included in this PR):
- Unit tests for ECDSA and Ed25519 (PKCS8 PEM + raw base64): signature verification, claim/header checks (iss/sub/uri/kid/nonce, exp = nbf + 120, distinct nonces), and negative cases.
- e2e against the live API with both an ECDSA and an Ed25519 key: listAccounts, getProduct, getBestBidAsk, listOrders all pass on both, plus an unauthenticated getServerTime.